### PR TITLE
Allow crowd sound to be loaded from https

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -53,7 +53,7 @@ var soundSource, concertHallBuffer;
 
 ajaxRequest = new XMLHttpRequest();
 
-ajaxRequest.open('GET', 'http://mdn.github.io/voice-change-o-matic/audio/concert-crowd.ogg', true);
+ajaxRequest.open('GET', '//mdn.github.io/voice-change-o-matic/audio/concert-crowd.ogg', true);
 
 ajaxRequest.responseType = 'arraybuffer';
 


### PR DESCRIPTION
In chrome, I get:
app.js:75 Mixed Content: The page at 'https://mdn.github.io/voice-change-o-matic/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://mdn.github.io/voice-change-o-matic/audio/concert-crowd.ogg'. This request has been blocked; the content must be served over HTTPS.

I believe this fixes the problem when loading the page over https.
