### PR TITLE
Resolve recently deprecated setter methods

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -229,7 +229,7 @@ function visualize() {
 function voiceChange() {
 
   distortion.oversample = '4x';
-  biquadFilter.gain.value = 0;
+  biquadFilter.gain.setTargetAtTime(0, audioCtx.currentTime, 0)
   convolver.buffer = undefined;
 
   var voiceSetting = voiceSelect.value;
@@ -241,8 +241,7 @@ function voiceChange() {
     convolver.buffer = concertHallBuffer;
   } else if(voiceSetting == "biquad") {
     biquadFilter.type = "lowshelf";
-    biquadFilter.frequency.value = 1000;
-    biquadFilter.gain.value = 25;
+    biquadFilter.gain.setTargetAtTime(25, audioCtx.currentTime, 0)
   } else if(voiceSetting == "off") {
     console.log("Voice settings turned off");
   }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -264,7 +264,7 @@ mute.onclick = voiceMute;
 
 function voiceMute() {
   if(mute.id === "") {
-    gainNode.gain.value = 0;
+    gainNode.gain.setTargetAtTime(0, audioCtx.currentTime, 0)
     mute.id = "activated";
     mute.innerHTML = "Unmute";
   } else {

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -241,6 +241,7 @@ function voiceChange() {
     convolver.buffer = concertHallBuffer;
   } else if(voiceSetting == "biquad") {
     biquadFilter.type = "lowshelf";
+    biquadFilter.frequency.setTargetAtTime(1000, audioCtx.currentTime, 0)
     biquadFilter.gain.setTargetAtTime(25, audioCtx.currentTime, 0)
   } else if(voiceSetting == "off") {
     console.log("Voice settings turned off");

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -267,7 +267,7 @@ function voiceMute() {
     mute.id = "activated";
     mute.innerHTML = "Unmute";
   } else {
-    gainNode.gain.value = 1;
+    gainNode.gain.setTargetAtTime(1, audioCtx.currentTime, 0)
     mute.id = "";
     mute.innerHTML = "Mute";
   }


### PR DESCRIPTION
[Deprecation] BiquadFilterNode.gain.value setter smoothing is deprecated and will be removed in M64, around January 2018. Please use setTargetAtTime() instead if smoothing is needed. See [](https://www.chromestatus.com/features/5287995770929152) for more details.

- BiquadFilterNode.frequency.value setter
- GainNode.gain.value setter